### PR TITLE
カラータグで16進数指定を行うと改行位置がおかしくなるのを修正

### DIFF
--- a/Assets/HyphenationJpn.cs
+++ b/Assets/HyphenationJpn.cs
@@ -180,7 +180,7 @@ public class HyphenationJpn : UIBehaviour
 		("abcdefghijklmnopqrstuvwxyz" +
 	     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + 
 	     "0123456789" + 
-	     "<>=/().,").ToCharArray();
+	     "<>=/().,#").ToCharArray();
 
 	private static bool CHECK_HYP_FRONT(char str)
 	{


### PR DESCRIPTION
　`<color=#ffffffff>`のような色指定を行うと改行位置がおかしくなるので、修正しました。
　`#`があるとタグとして処理できなくなるのが原因です。
