### PR TITLE
Fix hyphenation bug

### DIFF
--- a/Assets/HyphenationJpn.cs
+++ b/Assets/HyphenationJpn.cs
@@ -89,7 +89,7 @@ public class HyphenationJpn : UIBehaviour
 		StringBuilder lineBuilder = new StringBuilder();
 
 		float lineWidth = 0;
-		foreach( var originalLine in GetWordList(Regex.Replace(msg, "\r\n", "\n")))
+		foreach( var originalLine in GetWordList(Regex.Replace(msg, Environment.NewLine, "\n")))
 		{
 			lineWidth += GetTextWidth(textComp, originalLine);
 

--- a/Assets/HyphenationJpn.cs
+++ b/Assets/HyphenationJpn.cs
@@ -51,7 +51,7 @@ public class HyphenationJpn : UIBehaviour
 		_Text.text = GetFormatedText(_Text, str);
 	}
 	
-	public void GetText(string str)
+	public void SetText(string str)
 	{
 		text = str;
 		UpdateText(text);
@@ -89,11 +89,11 @@ public class HyphenationJpn : UIBehaviour
 		StringBuilder lineBuilder = new StringBuilder();
 
 		float lineWidth = 0;
-		foreach( var originalLine in GetWordList(msg))
+		foreach( var originalLine in GetWordList(Regex.Replace(msg, "\r\n", "\n")))
 		{
 			lineWidth += GetTextWidth(textComp, originalLine);
 
-			if( originalLine == Environment.NewLine ){
+			if( originalLine == "\n"){
 				lineWidth = 0;
 			}else{
 				if( originalLine == " " ){
@@ -128,7 +128,8 @@ public class HyphenationJpn : UIBehaviour
 			if( ((IsLatin(currentCharacter) && IsLatin(preCharacter) ) && (IsLatin(currentCharacter) && !IsLatin(preCharacter))) ||
 			    (!IsLatin(currentCharacter) && CHECK_HYP_BACK(preCharacter)) ||
 			    (!IsLatin(nextCharacter) && !CHECK_HYP_FRONT(nextCharacter) && !CHECK_HYP_BACK(currentCharacter))||
-			    (characterCount == tmpText.Length - 1)){
+			    (characterCount == tmpText.Length - 1) ||
+			    (currentCharacter == '\n')){
 				words.Add(line.ToString());
 				line = new StringBuilder();
 				continue;


### PR DESCRIPTION
以下のように文章の途中でに改行が入っていた場合、

> 親譲りの無鉄砲で小供の時から損ばかりしている。
> 小学校に居る時分学校の二階から
> 飛び降りて一週間ほど腰を抜かした事がある。

次のように改行に失敗するので

> 親譲りの無鉄砲で小供の時から損ばかりしている。
> 小学校に居る時分学校の二階から
> 飛び降りて一週間
> ほど腰を抜かした事がある。

正しく改行出来るように修正しました。
併せてGetText()をSetText()に変更しました。